### PR TITLE
Change SyncHTTP1Connection.send_request to async

### DIFF
--- a/urllib3/sync_connection.py
+++ b/urllib3/sync_connection.py
@@ -345,7 +345,7 @@ class SyncHTTP1Connection(object):
 
         return conn
 
-    def send_request(self, request):
+    async def send_request(self, request):
         """
         Given a Request object, performs the logic required to get a response.
         """


### PR DESCRIPTION
If this is synchronous, we would need to instead switch the return to:
`return await (self._start_http_request(request, self._state_machine, self._sock))`
to avoid a SyntaxError