### PR TITLE
Send request through trio backend

### DIFF
--- a/trio_test.py
+++ b/trio_test.py
@@ -1,0 +1,12 @@
+import trio
+import urllib3
+from urllib3.backends.trio_backend import TrioBackend
+
+
+async def main():
+    http = urllib3.PoolManager(TrioBackend())
+    r = await http.request('GET', 'http://httpbin.org/robots.txt', preload_content=False)
+    print(r.status)  # prints "200"
+    print(await r.read())  # prints "User-agent: *\nDisallow: /deny\n"
+
+trio.run(main)

--- a/urllib3/backends/_util.py
+++ b/urllib3/backends/_util.py
@@ -15,6 +15,7 @@ except (OSError, AttributeError):
 else:
     DEFAULT_SELECTOR = selectors.PollSelector
 
+
 def is_readable(sock):
     s = DEFAULT_SELECTOR()
     s.register(sock, selectors.EVENT_READ)

--- a/urllib3/backends/sync_backend.py
+++ b/urllib3/backends/sync_backend.py
@@ -1,3 +1,6 @@
+import errno
+import select
+import socket
 import ssl
 from ..util.connection import create_connection
 from ..util.ssl_ import ssl_wrap_socket
@@ -9,6 +12,7 @@ from ._util import DEFAULT_SELECTOR, is_readable
 __all__ = ["SyncBackend"]
 
 BUFSIZE = 65536
+
 
 class SyncBackend(object):
     def __init__(self, connect_timeout, read_timeout):
@@ -72,7 +76,7 @@ class SyncSocket(object):
                 else:
                     raise
 
-    async def send_and_receive_for_a_while(produce_bytes, consume_bytes):
+    async def send_and_receive_for_a_while(self, produce_bytes, consume_bytes):
         outgoing_finished = False
         outgoing = b""
         try:

--- a/urllib3/backends/trio_backend.py
+++ b/urllib3/backends/trio_backend.py
@@ -3,6 +3,9 @@ import trio
 from . import LoopAbort
 from ._util import is_readable
 
+BUFSIZE = 65536
+
+
 class TrioBackend:
     async def connect(
             self, host, port, source_address=None, socket_options=None):
@@ -23,6 +26,8 @@ class TrioBackend:
 # cancellation, but we probably should do something to detect when the stream
 # has been broken by cancellation (e.g. a timeout) and make is_readable return
 # True so the connection won't be reused.
+
+
 class TrioSocket:
     def __init__(self, stream):
         self._stream = stream
@@ -40,7 +45,7 @@ class TrioSocket:
     async def receive_some(self):
         return await self._stream.receive_some(BUFSIZE)
 
-    async def send_and_receive_for_a_while(produce_bytes, consume_bytes):
+    async def send_and_receive_for_a_while(self, produce_bytes, consume_bytes):
         async def sender():
             while True:
                 outgoing = await produce_bytes()
@@ -50,7 +55,7 @@ class TrioSocket:
 
         async def receiver():
             while True:
-                incoming = await stream.receive_some(BUFSIZE)
+                incoming = await self._stream.receive_some(BUFSIZE)
                 consume_bytes(incoming)
 
         try:
@@ -73,6 +78,6 @@ class TrioSocket:
             sock_stream = sock_stream.transport_stream
         sock = sock_stream.socket
         return is_readable(sock)
-        
+
     def set_readable_watch_state(self, enabled):
         pass

--- a/urllib3/backends/trio_backend.py
+++ b/urllib3/backends/trio_backend.py
@@ -60,13 +60,13 @@ class TrioSocket:
 
         try:
             async with trio.open_nursery() as nursery:
-                nursery.spawn(sender)
-                nursery.spawn(receiver)
+                nursery.start_soon(sender)
+                nursery.start_soon(receiver)
         except LoopAbort:
             pass
 
-    def forceful_close(self):
-        self._stream.forceful_close()
+    async def forceful_close(self):
+        await trio.aclose_forcefully(self._stream)
 
     def is_readable(self):
         # This is a bit of a hack, but I can't think of a better API that trio

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -148,11 +148,11 @@ class HTTPResponse(io.IOBase):
 
         return False
 
-    def release_conn(self):
+    async def release_conn(self):
         if not self._pool or not self._connection:
             return
 
-        self._pool._put_conn(self._connection)
+        await self._pool._put_conn(self._connection)
         self._connection = None
 
     @property
@@ -264,10 +264,11 @@ class HTTPResponse(io.IOBase):
 
             # If we hold the original response but it's finished now, we should
             # return the connection back to the pool.
-            if self._original_response and self._original_response.complete:
+            # XXX
+            if False and self._original_response and self._original_response.complete:
                 self.release_conn()
 
-    def read(self, amt=None, decode_content=None, cache_content=False):
+    async def read(self, amt=None, decode_content=None, cache_content=False):
         """
         Similar to :meth:`httplib.HTTPResponse.read`, but with two additional
         parameters: ``decode_content`` and ``cache_content``.

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -306,7 +306,8 @@ class HTTPResponse(io.IOBase):
 
         with self._error_catcher():
             if amt is None:
-                data += b''.join(self.stream(decode_content))
+                async for chunk in self.stream(decode_content):
+                    data += chunk
                 self._buffer = b''
 
                 # We only cache the body data for simple read calls.
@@ -331,7 +332,7 @@ class HTTPResponse(io.IOBase):
 
         return data
 
-    def stream(self, decode_content=None):
+    async def stream(self, decode_content=None):
         """
         A generator wrapper for the read() method.
 
@@ -348,7 +349,7 @@ class HTTPResponse(io.IOBase):
             decode_content = self.decode_content
 
         with self._error_catcher():
-            for raw_chunk in self._fp:
+            async for raw_chunk in self._fp:
                 self._fp_bytes_read += len(raw_chunk)
                 decoded_chunk = self._decode(
                     raw_chunk, decode_content, flush_decoder=False

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -306,8 +306,10 @@ class HTTPResponse(io.IOBase):
 
         with self._error_catcher():
             if amt is None:
+                chunks = []
                 async for chunk in self.stream(decode_content):
-                    data += chunk
+                    chunks.append(chunk)
+                data += b''.join(chunks)
                 self._buffer = b''
 
                 # We only cache the body data for simple read calls.

--- a/urllib3/sync_connection.py
+++ b/urllib3/sync_connection.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import
 
 import collections
 import datetime
-import errno
-import itertools
 import socket
 import warnings
 
@@ -30,7 +28,7 @@ from .exceptions import (
     ProtocolError
 )
 from .packages import six
-from .util import selectors, connection, ssl_ as ssl_util
+from .util import ssl_ as ssl_util
 from .backends import LoopAbort
 
 try:
@@ -147,7 +145,7 @@ def _response_from_h11(h11_response, body_object):
     Given a h11 Response object, build a urllib3 response object and return it.
     """
     if h11_response.http_version not in _SUPPORTED_VERSIONS:
-        raise BadVersionError(response.http_version)
+        raise BadVersionError(h11_response.http_version)
 
     version = b'HTTP/' + h11_response.http_version
     our_response = Response(
@@ -201,6 +199,7 @@ async def _start_http_request(self, request, state_machine, conn):
     request_bytes_iterable = _request_bytes_iterable(request, state_machine)
 
     send_aborted = True
+
     async def next_bytes_to_send():
         nonlocal send_aborted
         try:
@@ -211,6 +210,7 @@ async def _start_http_request(self, request, state_machine, conn):
             return None
 
     h11_response = None
+
     def consume_bytes(data):
         nonlocal h11_response
 
@@ -229,7 +229,7 @@ async def _start_http_request(self, request, state_machine, conn):
             else:
                 # Can't happen
                 raise RuntimeError("Unexpected h11 event {}".format(event))
-            
+
     await conn.send_and_receive_for_a_while(
         next_bytes_to_send, consume_bytes)
     assert h11_response is not None
@@ -242,7 +242,7 @@ async def _start_http_request(self, request, state_machine, conn):
         # re-use this connection, even though we can't. So record this in
         # h11's state machine.
         # XX need to implement this in h11
-        #state_machine.poison()
+        # state_machine.poison()
         # XX kluge for now
         state_machine._cstate.process_error(state_machine.our_role)
 
@@ -373,11 +373,12 @@ class SyncHTTP1Connection(object):
         if tunnel_response.status_code != 200:
             conn.forceful_close()
             raise FailedTunnelError(
-                "Unable to establish CONNECT tunnel", response
+                "Unable to establish CONNECT tunnel", tunnel_response
             )
 
     async def connect(self, ssl_context=None,
-                fingerprint=None, assert_hostname=None):
+                      fingerprint=None, assert_hostname=None,
+                      connect_timeout=None):
         """
         Connect this socket to the server, applying the source address, any
         relevant socket options, and the relevant connection timeout.
@@ -393,12 +394,14 @@ class SyncHTTP1Connection(object):
 
         if self._socket_options:
             extra_kw['socket_options'] = self._socket_options
+        # XX pass connect_timeout to backend
 
         # This was factored out into a separate function to allow overriding
         # by subclasses, but in the backend approach the way to to this is to
         # provide a custom backend. (Composition >> inheritance.)
         try:
-            conn = await self._backend.connect(self._host, self._port, **connect_kw)
+            conn = await self._backend.connect(
+                self._host, self._port, **extra_kw)
         # XX these two error handling blocks needs to be re-done in a
         # backend-agnostic way
         except socket.timeout:

--- a/urllib3/sync_connection.py
+++ b/urllib3/sync_connection.py
@@ -179,6 +179,76 @@ def _build_tunnel_request(host, port, headers):
     return tunnel_request
 
 
+async def _start_http_request(request, state_machine, conn):
+    """
+    Send the request using the given state machine and connection, wait
+    for the response headers, and return them.
+
+    If we get response headers early, then we stop sending and return
+    immediately, poisoning the state machine along the way so that we know
+    it can't be re-used.
+
+    This is a standalone function because we use it both to set up both
+    CONNECT requests and real requests.
+    """
+    # Before we begin, confirm that the state machine is ok.
+    if (state_machine.our_state is not h11.IDLE or
+            state_machine.their_state is not h11.IDLE):
+        raise ProtocolError("Invalid internal state transition")
+
+    request_bytes_iterable = _request_bytes_iterable(request, state_machine)
+
+    send_aborted = True
+
+    async def next_bytes_to_send():
+        nonlocal send_aborted
+        try:
+            return next(request_bytes_iterable)
+        except StopIteration:
+            # We successfully sent the whole body!
+            send_aborted = False
+            return None
+
+    h11_response = None
+
+    def consume_bytes(data):
+        nonlocal h11_response
+
+        state_machine.receive_data(data)
+        while True:
+            event = state_machine.next_event()
+            if event is h11.NEED_DATA:
+                break
+            elif isinstance(event, h11.InformationalResponse):
+                # Ignore 1xx responses
+                continue
+            elif isinstance(event, h11.Response):
+                # We have our response! Save it and get out of here.
+                h11_response = event
+                raise LoopAbort
+            else:
+                # Can't happen
+                raise RuntimeError("Unexpected h11 event {}".format(event))
+
+    await conn.send_and_receive_for_a_while(
+        next_bytes_to_send, consume_bytes)
+    assert h11_response is not None
+
+    if send_aborted:
+        # Our state machine thinks we sent a bunch of data... but maybe we
+        # didn't! Maybe our send got cancelled while we were only half-way
+        # through sending the last chunk, and then h11 thinks we sent a
+        # complete request and we actually didn't. Then h11 might think we can
+        # re-use this connection, even though we can't. So record this in
+        # h11's state machine.
+        # XX need to implement this in h11
+        # state_machine.poison()
+        # XX kluge for now
+        state_machine._cstate.process_error(state_machine.our_role)
+
+    return h11_response
+
+
 async def _read_until_event(state_machine, conn):
     """
     A loop that keeps issuing reads and feeding the data into h11 and
@@ -279,9 +349,10 @@ class SyncHTTP1Connection(object):
         """
         Given a Request object, performs the logic required to get a response.
         """
-        return await self._start_http_request(
+        h11_response = await _start_http_request(
             request, self._state_machine, self._sock
         )
+        return _response_from_h11(h11_response, self)
 
     async def _tunnel(self, conn):
         """
@@ -296,11 +367,12 @@ class SyncHTTP1Connection(object):
 
         tunnel_state_machine = h11.Connection(our_role=h11.CLIENT)
 
-        tunnel_response = await self._start_http_request(
+        h11_response = await _start_http_request(
             tunnel_request, tunnel_state_machine, conn
         )
+        tunnel_response = _response_from_h11(h11_response, self)
 
-        if tunnel_response.status_code != 200:
+        if h11_response.status_code != 200:
             conn.forceful_close()
             raise FailedTunnelError(
                 "Unable to establish CONNECT tunnel", tunnel_response
@@ -353,75 +425,6 @@ class SyncHTTP1Connection(object):
 
         # XX We should pick one of these names and use it consistently...
         self._sock = conn
-
-    async def _start_http_request(self, request, state_machine, conn):
-        """
-        Send the request using the given state machine and connection, wait
-        for the response headers, and return them.
-
-        If we get response headers early, then we stop sending and return
-        immediately, poisoning the state machine along the way so that we know
-        it can't be re-used.
-
-        This is a standalone function because we use it both to set up both
-        CONNECT requests and real requests.
-        """
-        # Before we begin, confirm that the state machine is ok.
-        if (state_machine.our_state is not h11.IDLE or
-                state_machine.their_state is not h11.IDLE):
-            raise ProtocolError("Invalid internal state transition")
-
-        request_bytes_iterable = _request_bytes_iterable(request, state_machine)
-
-        send_aborted = True
-
-        async def next_bytes_to_send():
-            nonlocal send_aborted
-            try:
-                return next(request_bytes_iterable)
-            except StopIteration:
-                # We successfully sent the whole body!
-                send_aborted = False
-                return None
-
-        h11_response = None
-
-        def consume_bytes(data):
-            nonlocal h11_response
-
-            state_machine.receive_data(data)
-            while True:
-                event = state_machine.next_event()
-                if event is h11.NEED_DATA:
-                    break
-                elif isinstance(event, h11.InformationalResponse):
-                    # Ignore 1xx responses
-                    continue
-                elif isinstance(event, h11.Response):
-                    # We have our response! Save it and get out of here.
-                    h11_response = event
-                    raise LoopAbort
-                else:
-                    # Can't happen
-                    raise RuntimeError("Unexpected h11 event {}".format(event))
-
-        await conn.send_and_receive_for_a_while(
-            next_bytes_to_send, consume_bytes)
-        assert h11_response is not None
-
-        if send_aborted:
-            # Our state machine thinks we sent a bunch of data... but maybe we
-            # didn't! Maybe our send got cancelled while we were only half-way
-            # through sending the last chunk, and then h11 thinks we sent a
-            # complete request and we actually didn't. Then h11 might think we can
-            # re-use this connection, even though we can't. So record this in
-            # h11's state machine.
-            # XX need to implement this in h11
-            # state_machine.poison()
-            # XX kluge for now
-            state_machine._cstate.process_error(state_machine.our_role)
-
-        return _response_from_h11(h11_response, self)
 
     async def close(self):
         """


### PR DESCRIPTION
I gave a try at the mechanical parts of njsmith/urllib3#1, ie. passing the backend from the pools to the connection, adding async/await keywords, and fixing minor issue in the trio backend.

Running `python3 test_trio.py` prints:

```
Response(status_code=200, headers=[(b'connection', b'keep-alive'), (b'server', b'meinheld/0.6.1'), (b'date', b'Tue, 02 Jan 2018 02:12:45 GMT'), (b'content-type', b'text/plain'), (b'content-length', b'30'), (b'access-control-allow-origin', b'*'), (b'access-control-allow-credentials', b'true'), (b'x-powered-by', b'Flask'), (b'x-processed-time', b'0.00075101852417'), (b'via', b'1.1 vegur')], http_version=b'1.1', reason=b'OK')
200
b''
```

So we see the headers of the h11 response in the trio backend but I don't know how to expose that in the urllib3 Response object, ditto for the body which is just the empty byte string but should not be. I did not even try running the test suite, but can try to work on it if you want to.