### PR TITLE
Skip at test level

### DIFF
--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -25,7 +25,6 @@ def teardown_module():
     extract_from_urllib3()
 
 
-@pytest.mark.skip
 class TestPyOpenSSLHelpers(unittest.TestCase):
     """
     Tests for PyOpenSSL helper functions.

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -202,11 +202,11 @@ class TestSOCKSProxyManager(object):
         assert 'Unable to determine SOCKS version' in e.value.args[0]
 
 
-@pytest.mark.skip
 class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
     """
     Test the SOCKS proxy in SOCKS5 mode.
     """
+    @pytest.mark.skip
     def test_basic_request(self):
         def request_handler(listener):
             sock = listener.accept()[0]
@@ -239,6 +239,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.data, b'')
         self.assertEqual(response.headers['Server'], 'SocksTestServer')
 
+    @pytest.mark.xfail
     def test_local_dns(self):
         def request_handler(listener):
             sock = listener.accept()[0]
@@ -304,6 +305,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         response = pm.request('GET', 'http://example.com')
         self.assertEqual(response.status, 200)
 
+    @pytest.mark.xfail
     def test_connection_timeouts(self):
         event = threading.Event()
 
@@ -321,6 +323,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         )
         event.set()
 
+    @pytest.mark.xfail
     def test_connection_failure(self):
         event = threading.Event()
 
@@ -339,6 +342,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             retries=False
         )
 
+    @pytest.mark.xfail
     def test_proxy_rejection(self):
         evt = threading.Event()
 
@@ -363,6 +367,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         )
         evt.set()
 
+    @pytest.mark.skip
     def test_socks_with_password(self):
         def request_handler(listener):
             sock = listener.accept()[0]
@@ -399,6 +404,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.data, b'')
         self.assertEqual(response.headers['Server'], 'SocksTestServer')
 
+    @pytest.mark.xfail
     def test_socks_with_invalid_password(self):
         def request_handler(listener):
             sock = listener.accept()[0]
@@ -421,6 +427,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         else:
             self.fail("Did not raise")
 
+    @pytest.mark.xfail
     def test_source_address_works(self):
         expected_port = _get_free_port(self.host)
 
@@ -457,7 +464,6 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.status, 200)
 
 
-@pytest.mark.skip
 class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
     """
     Test the SOCKS proxy in SOCKS4 mode.
@@ -465,6 +471,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
     Has relatively fewer tests than the SOCKS5 case, mostly because once the
     negotiation is done the two cases behave identically.
     """
+    @pytest.mark.skip
     def test_basic_request(self):
         def request_handler(listener):
             sock = listener.accept()[0]
@@ -497,6 +504,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.headers['Server'], 'SocksTestServer')
         self.assertEqual(response.data, b'')
 
+    @pytest.mark.xfail
     def test_local_dns(self):
         def request_handler(listener):
             sock = listener.accept()[0]
@@ -562,6 +570,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         response = pm.request('GET', 'http://example.com')
         self.assertEqual(response.status, 200)
 
+    @pytest.mark.xfail
     def test_proxy_rejection(self):
         evt = threading.Event()
 
@@ -586,6 +595,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         )
         evt.set()
 
+    @pytest.mark.skip
     def test_socks4_with_username(self):
         def request_handler(listener):
             sock = listener.accept()[0]
@@ -618,6 +628,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         self.assertEqual(response.data, b'')
         self.assertEqual(response.headers['Server'], 'SocksTestServer')
 
+    @pytest.mark.xfail
     def test_socks_with_invalid_username(self):
         def request_handler(listener):
             sock = listener.accept()[0]
@@ -638,11 +649,11 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
             self.fail("Did not raise")
 
 
-@pytest.mark.skip
 class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
     """
     Test that TLS behaves properly for SOCKS proxies.
     """
+    @pytest.mark.skip
     @pytest.mark.skipif(not HAS_SSL, reason='No TLS available')
     def test_basic_request(self):
         def request_handler(listener):

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -202,7 +202,7 @@ class TestSOCKSProxyManager(object):
         assert 'Unable to determine SOCKS version' in e.value.args[0]
 
 
-class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
+class TestSOCKS5Proxy(IPV4SocketDummyServerTestCase):
     """
     Test the SOCKS proxy in SOCKS5 mode.
     """

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 from urllib3 import HTTPConnectionPool
 from urllib3.exceptions import InvalidBodyError
 from urllib3.packages import six
 from dummyserver.testcase import SocketDummyServerTestCase
 
-import pytest
 
-
-@pytest.mark.skip
 class TestChunkedTransfer(SocketDummyServerTestCase):
     def start_chunked_handler(self):
         self.buffer = b''
@@ -28,6 +27,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
 
+    @pytest.mark.skip
     def test_chunks(self):
         self.start_chunked_handler()
         chunks = [b'foo', b'bar', b'', b'bazzzzzzzzzzzzzzzzzzzzzz']
@@ -64,20 +64,25 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
         else:
             self.assertEqual(body, b'0\r\n\r\n')
 
+    @pytest.mark.skip
     def test_bytestring_body(self):
         self._test_body(b'thisshouldbeonechunk\r\nasdf')
 
+    @pytest.mark.skip
     def test_unicode_body(self):
         # Unicode bodies are not supported.
         chunk = u'thisshouldbeonechunk\r\näöüß'
         self.assertRaises(InvalidBodyError, self._test_body, chunk)
 
+    @pytest.mark.skip
     def test_empty_string_body(self):
         self._test_body(b'')
 
+    @pytest.mark.skip
     def test_empty_iterable_body(self):
         self._test_body([])
 
+    @pytest.mark.skip
     def test_removes_duplicate_host_header(self):
         self.start_chunked_handler()
         chunks = [b'foo', b'bar', b'', b'bazzzzzzzzzzzzzzzzzzzzzz']
@@ -93,6 +98,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
         host_headers = [x for x in header_lines if x.startswith(b'host')]
         self.assertEqual(len(host_headers), 1)
 
+    @pytest.mark.skip
     def test_provides_default_host_header(self):
         self.start_chunked_handler()
         chunks = [b'foo', b'bar', b'', b'bazzzzzzzzzzzzzzzzzzzzzz']

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -47,9 +47,9 @@ def wait_for_socket(ready_event):
     ready_event.clear()
 
 
-@pytest.mark.skip
 class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
 
+    @pytest.mark.skip
     def test_timeout_float(self):
         block_event = Event()
         ready_event = self.start_basic_handler(block_send=block_event, num=2)
@@ -66,6 +66,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         block_event.set()  # Pre-release block
         pool.request('GET', '/')
 
+    @pytest.mark.skip
     def test_conn_closed(self):
         block_event = Event()
         self.start_basic_handler(block_send=block_event, num=1)
@@ -85,6 +86,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
 
         block_event.set()
 
+    @pytest.mark.skip
     def test_timeout(self):
         # Requests should time out when expected
         block_event = Event()
@@ -145,6 +147,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
                           timeout=SHORT_TIMEOUT)
         block_event.set()  # Release request
 
+    @pytest.mark.skip
     def test_connect_timeout(self):
         url = '/'
         host, port = TARPIT_HOST, 80
@@ -173,6 +176,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         pool._put_conn(conn)
         self.assertRaises(ConnectTimeoutError, pool.request, 'GET', url, timeout=timeout)
 
+    @pytest.mark.skip
     def test_total_applies_connect(self):
         host, port = TARPIT_HOST, 80
 
@@ -190,6 +194,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         self.addCleanup(conn.close)
         self.assertRaises(ConnectTimeoutError, pool._make_request, conn, 'GET', '/')
 
+    @pytest.mark.skip
     def test_total_timeout(self):
         block_event = Event()
         ready_event = self.start_basic_handler(block_send=block_event, num=2)
@@ -211,6 +216,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         self.addCleanup(pool.close)
         self.assertRaises(ReadTimeoutError, pool.request, 'GET', '/')
 
+    @pytest.mark.xfail
     def test_create_connection_timeout(self):
         timeout = Timeout(connect=SHORT_TIMEOUT, total=LONG_TIMEOUT)
         pool = HTTPConnectionPool(TARPIT_HOST, self.port, timeout=timeout, retries=False)
@@ -223,7 +229,6 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         )
 
 
-@pytest.mark.skip
 class TestConnectionPool(HTTPDummyServerTestCase):
 
     def setUp(self):
@@ -235,6 +240,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
                               fields={'method': 'GET'})
         self.assertEqual(r.status, 200, r.data)
 
+    @pytest.mark.skip
     def test_post_url(self):
         r = self.pool.request('POST', '/specific_method',
                               fields={'method': 'POST'})
@@ -244,6 +250,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         r = self.pool.urlopen('PUT', '/specific_method?method=PUT')
         self.assertEqual(r.status, 200, r.data)
 
+    @pytest.mark.skip
     def test_wrong_specific_method(self):
         # To make sure the dummy server is actually returning failed responses
         r = self.pool.request('GET', '/specific_method',
@@ -254,6 +261,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
                               fields={'method': 'GET'})
         self.assertEqual(r.status, 400, r.data)
 
+    @pytest.mark.skip
     def test_upload(self):
         data = "I'm in ur multipart form-data, hazing a cheezburgr"
         fields = {
@@ -266,6 +274,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         r = self.pool.request('POST', '/upload', fields=fields)
         self.assertEqual(r.status, 200, r.data)
 
+    @pytest.mark.skip
     def test_one_name_multiple_values(self):
         fields = [
             ('foo', 'a'),
@@ -280,6 +289,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         r = self.pool.request('POST', '/echo', fields=fields)
         self.assertEqual(r.data.count(b'name="foo"'), 2)
 
+    @pytest.mark.skip
     def test_request_method_body(self):
         body = b'hi'
         r = self.pool.request('POST', '/echo', body=body)
@@ -288,6 +298,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         fields = [('hi', 'hello')]
         self.assertRaises(TypeError, self.pool.request, 'POST', '/echo', body=body, fields=fields)
 
+    @pytest.mark.skip
     def test_unicode_upload(self):
         fieldname = u('myfile')
         filename = u('\xe2\x99\xa5.txt')
@@ -304,6 +315,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         r = self.pool.request('POST', '/upload', fields=fields)
         self.assertEqual(r.status, 200, r.data)
 
+    @pytest.mark.xfail
     def test_nagle(self):
         """ Test that connections have TCP_NODELAY turned on """
         # This test needs to be here in order to be run. socket.create_connection actually tries
@@ -316,6 +328,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         tcp_nodelay_setting = conn._sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
         self.assertTrue(tcp_nodelay_setting)
 
+    @pytest.mark.xfail
     def test_socket_options(self):
         """Test that connections accept socket options."""
         # This test needs to be here in order to be run. socket.create_connection actually tries to
@@ -330,6 +343,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertTrue(using_keepalive)
         s.close()
 
+    @pytest.mark.xfail
     def test_disable_default_socket_options(self):
         """Test that passing None disables all socket options."""
         # This test needs to be here in order to be run. socket.create_connection actually tries
@@ -342,6 +356,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertTrue(using_nagle)
         s.close()
 
+    @pytest.mark.xfail
     def test_defaults_are_applied(self):
         """Test that modifying the default socket options works."""
         # This test needs to be here in order to be run. socket.create_connection actually tries
@@ -389,6 +404,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.addCleanup(pool.close)
         pool.request('GET', '/')
 
+    @pytest.mark.xfail
     def test_redirect(self):
         r = self.pool.request('GET', '/redirect', fields={'target': '/'}, redirect=False)
         self.assertEqual(r.status, 303)
@@ -405,6 +421,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         except MaxRetryError as e:
             self.assertEqual(type(e.reason), NewConnectionError)
 
+    @pytest.mark.skip
     def test_keepalive(self):
         pool = HTTPConnectionPool(self.host, self.port, block=True, maxsize=1)
         self.addCleanup(pool.close)
@@ -416,6 +433,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertEqual(pool.num_connections, 1)
         self.assertEqual(pool.num_requests, 2)
 
+    @pytest.mark.skip
     def test_keepalive_close(self):
         pool = HTTPConnectionPool(self.host, self.port,
                                   block=True, maxsize=1, timeout=2)
@@ -466,11 +484,13 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         # Next request
         r = pool.request('GET', '/keepalive?close=0')
 
+    @pytest.mark.skip
     def test_post_with_urlencode(self):
         data = {'banana': 'hammock', 'lol': 'cat'}
         r = self.pool.request('POST', '/echo', fields=data, encode_multipart=False)
         self.assertEqual(r.data.decode('utf-8'), urlencode(data))
 
+    @pytest.mark.skip
     def test_post_with_multipart(self):
         data = {'banana': 'hammock', 'lol': 'cat'}
         r = self.pool.request('POST', '/echo',
@@ -517,6 +537,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
                           'GET', '/encodingrequest',
                           headers={'accept-encoding': 'garbage-gzip'})
 
+    @pytest.mark.xfail
     def test_connection_count(self):
         pool = HTTPConnectionPool(self.host, self.port, maxsize=1)
         self.addCleanup(pool.close)
@@ -528,6 +549,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertEqual(pool.num_connections, 1)
         self.assertEqual(pool.num_requests, 3)
 
+    @pytest.mark.xfail
     def test_connection_count_bigpool(self):
         http_pool = HTTPConnectionPool(self.host, self.port, maxsize=16)
         self.addCleanup(http_pool.close)
@@ -551,6 +573,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertEqual(r.read(5), resp_data[:5])
         self.assertEqual(r.read(), resp_data[5:])
 
+    @pytest.mark.skip
     def test_lazy_load_twice(self):
         # This test is sad and confusing. Need to figure out what's
         # going on with partial reads and socket reuse.
@@ -598,6 +621,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
         self.assertEqual(pool.num_connections, 1)
 
+    @pytest.mark.xfail
     def test_for_double_release(self):
         MAXSIZE = 5
 
@@ -661,6 +685,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
                               pool.request,
                               'GET', '/source_address?{0}'.format(addr))
 
+    @pytest.mark.xfail
     def test_stream_keepalive(self):
         x = 2
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -116,6 +116,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 error = call[0][1]
                 self.assertEqual(error, InsecurePlatformWarning)
 
+    @pytest.mark.xfail
     def test_verified_with_context(self):
         ctx = util.ssl_.create_urllib3_context(cert_reqs=ssl.CERT_REQUIRED)
         ctx.load_verify_locations(cafile=DEFAULT_CA)
@@ -140,6 +141,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 error = call[0][1]
                 self.assertEqual(error, InsecurePlatformWarning)
 
+    @pytest.mark.xfail
     def test_context_combines_with_ca_certs(self):
         ctx = util.ssl_.create_urllib3_context(cert_reqs=ssl.CERT_REQUIRED)
         https_pool = HTTPSConnectionPool(self.host, self.port,


### PR DESCRIPTION
We want to minimize the number of skipped tests, and maximize successful (!) and xfailed tests.

The exception is the `pytestmark` in `test/contrib/test_securetransport.py`: it did not change anything: all affected tests do timeout.