### PR TITLE
Bump requirements versions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,22 +1,22 @@
-mock==1.3.0
-coverage==3.7.1
+mock==2.0.0
+coverage==4.5.1
 tox==2.9.1
-twine==1.5.0
+twine==1.11.0
 wheel==0.30.0
-tornado==4.2.1
-PySocks==1.5.6
-pkginfo>=1.0,!=1.3.0
-psutil==4.3.1
+tornado==4.5.3
+PySocks==1.6.8
+pkginfo==1.4.2
+psutil==5.4.3
 pytest-cov==2.5.1
 pytest-random-order==0.6.0
-pytest-timeout==1.2.0
-pytest==3.4.0
-gcp-devrel-py-tools==0.0.7
+pytest-timeout==1.2.1
+pytest==3.4.2
+gcp-devrel-py-tools==0.0.13
 h11==0.8.0
 # Temporary pin to work around:
 #   https://github.com/shazow/urllib3/issues/1340
 #   https://github.com/shazow/urllib3/issues/1341
-cryptography==2.1.4
+cryptography==2.2.1
 trio==0.3.0
 twisted[tls,windows_platform]==17.9.0; os_name == 'nt'
 twisted[tls]==17.9.0; os_name != 'nt'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,7 @@ PySocks==1.5.6
 pkginfo>=1.0,!=1.3.0
 psutil==4.3.1
 pytest-cov==2.5.1
+pytest-random-order==0.6.0
 pytest-timeout==1.2.0
 pytest==3.4.0
 gcp-devrel-py-tools==0.0.7
@@ -16,3 +17,6 @@ h11==0.8.0
 #   https://github.com/shazow/urllib3/issues/1340
 #   https://github.com/shazow/urllib3/issues/1341
 cryptography==2.1.4
+trio==0.3.0
+twisted[tls,windows_platform]==17.9.0; os_name == 'nt'
+twisted[tls]==17.9.0; os_name != 'nt'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,9 +13,6 @@ pytest-timeout==1.2.1
 pytest==3.4.2
 gcp-devrel-py-tools==0.0.13
 h11==0.8.0
-# Temporary pin to work around:
-#   https://github.com/shazow/urllib3/issues/1340
-#   https://github.com/shazow/urllib3/issues/1341
 cryptography==2.2.1
 trio==0.3.0
 twisted[tls,windows_platform]==17.9.0; os_name == 'nt'

--- a/runtests.py
+++ b/runtests.py
@@ -48,14 +48,6 @@ def python(*args):
     run([python_exe, "-u"] + list(args))
 
 python("-m", "pip", "install", "-r", "dev-requirements.txt")
-# XX get rid of this extra pip call:
-if os.name == "nt":
-    twisted = "twisted[tls,windows_platform]"
-else:
-    twisted = "twisted[tls]"
-python("-u", "-m", "pip", "install", "trio", twisted)
-
-python("-m", "pip", "install", "pytest-random-order")
 
 print("-- Rebuilding urllib3/_sync in source tree --")
 python("setup.py", "build")

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,5 +19,5 @@ requires-dist =
     ipaddress; python_version<="2.7" and extra == 'secure'
     PySocks>=1.5.6,<2.0,!=1.5.7; extra == 'socks'
 
-[pytest]
+[tool:pytest]
 xfail_strict=true


### PR DESCRIPTION
The exception is tornado which is still pinned at 4.x.

Maybe we should use ~= to pin to major versions?