### PR TITLE
runtests: Stop displaying unrelated stack traces

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -25,7 +25,10 @@ os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
 
 def run(cmd):
     print(cmd)
-    return subprocess.check_call(cmd)
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as e:
+        sys.exit(e.returncode)
 
 venv = "test-venv-{}-{}".format(get_abi_tag(), get_platform())
 


### PR DESCRIPTION
But still return a non-zero integer on command errors, for CI.

So I scratch itch after itch on runtests.py, but maybe making tox work would not be that hard? I don't know.